### PR TITLE
Use serviceMonitor when scraping metrics for Prometheus by default

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,21 +1,6 @@
 apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
-
-# A chart can be either an 'application' or a 'library' chart.
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
 type: application
-
-# This is the chart version. This version number should be incremented each time you make changes
-# to the chart and its templates, including the app version.
-version: 0.3.1
-
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application.
+version: 0.4.0
 appVersion: 6.4

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # varnish-chart
+
 Helm chart for Varnish Cache
+

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -17,6 +17,7 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
       annotations:
+        rollme: {{ randAlphaNum 5 | quote }}
       {{- if and .Values.prometheus.enabled .Values.prometheus.scrape }}
         prometheus.io/scrape: "true"
         prometheus.io/path: "{{ .Values.prometheus.path }}"

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -11,5 +11,9 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+    - port: {{ .Values.prometheus.port }}
+      targetPort: http
+      protocol: TCP
+      name: exporter
   selector:
     {{- include "varnish.selectorLabels" . | nindent 4 }}

--- a/templates/servicemonitor.yaml
+++ b/templates/servicemonitor.yaml
@@ -1,0 +1,34 @@
+{{- if and ( .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" ) ( .Values.prometheus.serviceMonitor.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "varnish.name" .  }}
+  {{- if .Values.prometheus.serviceMonitor.namespace }}
+  namespace: {{ .Values.prometheus.serviceMonitor.namespace }}
+  {{- end }}
+  labels:
+  {{- include "varnish.labels" . | nindent 4 }}
+  {{- if .Values.prometheus.serviceMonitor.additionalLabels }}
+  {{ toYaml .Values.prometheus.serviceMonitor.additionalLabels | indent 4 }}
+  {{- end }}
+spec:
+  endpoints:
+    - targetPort: {{ .Values.prometheus.port }}
+      {{- if .Values.prometheus.serviceMonitor.interval }}
+      interval: {{ .Values.prometheus.serviceMonitor.interval }}
+      {{- end }}
+      {{- if .Values.prometheus.serviceMonitor.path }}
+      path: {{ .Values.prometheus.serviceMonitor.path }}
+      {{- end }}
+      {{- if .Values.prometheus.serviceMonitor.timeout }}
+      scrapeTimeout: {{ .Values.prometheus.serviceMonitor.timeout }}
+      honorLabels: {{ .Values.prometheus.serviceMonitor.honorLabels }}
+  {{- end }}
+  jobLabel: {{ template "varnish.fullname" . }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+  {{- include "varnish.selectorLabels" . | nindent 6 }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -99,5 +99,13 @@ prometheus:
     pullPolicy: IfNotPresent
   path: "/metrics"
   port: "9131"
-  scrape: true
+  scrape: false
   resources: {}
+  serviceMonitor:
+    enabled: true
+    additionalLabels: {}
+    honorLabels: true
+    interval: null
+    namespace: null
+    path: null
+    timeout: null


### PR DESCRIPTION
Instead of use the "old" scraping annotations for export Prometheus metrics we use ServiceMonitor CRD instead.

Signed-off-by: Basilio Vera <basilio.vera@softonic.com>