### PR TITLE
Manage varnish malloc cache size

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.5.2
+version: 0.6.0
 appVersion: 6.4

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: VARNISH_SIZE
+              value: {{ .Values.varnishSize }}
           ports:
             - name: http
               containerPort: 80

--- a/values.yaml
+++ b/values.yaml
@@ -77,6 +77,7 @@ resources: {}
 livenessProbe: {}
 readinessProbe: {}
 
+varnishSize: 100M
 
 nodeSelector: {}
 


### PR DESCRIPTION
Gives ability to manage varnish malloc cache size.

Currently uses the default container env $VARNISH_SIZE: 100M