### PR TITLE
Fix duplicate  declaration.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 6.4

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -77,7 +77,6 @@ spec:
           readinessProbe:
 {{ toYaml . | indent 12 }}
           {{- end }}
-          resources:
         {{- if .Values.logging.enabled }}
         - name: varnishncsa
           image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"


### PR DESCRIPTION
# Error duplicate declaration

Deployment `ressources` key is empty in kubernetes API.

Since the second declaration is empty, kubernetes API doesn't uses the user value  which is consumed by the first declaration (line 59)

e.g.
```
$ helm template varnish . -s templates/deployment.yaml | yq eval '.spec.template.spec.containers.[]|select(.name=="varnishd")' - | grep resources
resources: {}
resources:
```
The second one will stay empty (and kept by k8s api) even if you set user `resources` in values.yaml

# Fix
Delete the empty duplicate `resources` declaration 