### PR TITLE
BC: versioning from 0.1.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,12 +26,14 @@ package:
   variables:
     PACKAGE_NAME: "varnish"
     PACKAGE_VERSION: "0.6.2"
+  before_script:
+    - apk add git
+    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - 'helm repo add --username gitlab-ci-token --password ${CI_JOB_TOKEN} ${CI_PROJECT_NAME} ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - helm package ./
-    - apk add git
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
+    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" $PACKAGE_NAME
   only:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,8 +30,8 @@ package:
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - echo "$HELM_REPO_URL"
-    - helm repo index --url ${HELM_REPO_URL} .
+    - echo $HELM_REPO_URL
+    - helm repo index ./ --url $HELM_REPO_URL
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,12 +24,13 @@ container:
 package:
   stage: build-package
   variables:
-    CHART_VERSION: 0.6.2
+    PACKAGE_NAME: "varnish"
+    PACKAGE_VERSION: "0.6.2"
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - helm package ./
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - helm push "${CHART_NAME}-${CHART_VERSION}.tgz" $CHART_NAME
+    - helm push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -32,9 +32,10 @@ package:
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
-    - helm package ./
-    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" $CI_PROJECT_NAME
+#    - helm package ./
+    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME
   only:
-    - master
+    - tags
+#    - master
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,7 +9,8 @@ variables:
 
 stages:
   - build-container
-  - build-package
+#  - build-package
+  - build-pages
 
 container:
   stage: build-container
@@ -23,21 +24,41 @@ container:
   only:
     - tags
 
-package:
+
+pages:
   image: dtzar/helm-kubectl:3.7.1
-  stage: build-package
+  stage: build-pages
   variables:
-    HELM_REPO_URL: "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+    HELM_REPO_URL: "https://${CI_PROJECT_NAMESPACE}.gitlab.io/${CI_PROJECT_NAME}"
   before_script:
     - apk add git
-    - helm plugin install https://github.com/chartmuseum/helm-push.git
+    - mkdir -p ./public
     - echo $HELM_REPO_URL
-    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION"
-    - helm repo index ./ --url="$HELM_REPO_URL"
-    - helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
-    - helm cm-push ./ $CI_PROJECT_NAME
+    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION" --destination ./public
+    - helm repo index ./ --url="$HELM_REPO_URL"
+    - mv index.yaml ./public
+  artifacts:
+    paths:
+      - public
   only:
     - tags
+
+#package:
+#  image: dtzar/helm-kubectl:3.7.1
+#  stage: build-package
+#  variables:
+#    HELM_REPO_URL: "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+#  before_script:
+#    - apk add git
+#    - helm plugin install https://github.com/chartmuseum/helm-push.git
+#    - echo $HELM_REPO_URL
+#    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION"
+#    - helm repo index ./ --url="$HELM_REPO_URL"
+#    - helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+#  script:
+#    - helm cm-push ./ $CI_PROJECT_NAME
+#  only:
+#    - tags
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,7 +34,7 @@ package:
     - echo "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
-    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME/$CHART_NAME
+    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,11 +29,10 @@ package:
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - 'helm repo add --username gitlab-ci-token --password ${CI_JOB_TOKEN} ${CI_PROJECT_NAME} ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
+    - helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME '${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
-    - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - helm package ./
-    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" $PACKAGE_NAME
+    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" $CI_PROJECT_NAME
   only:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ package:
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME '${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
+    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
     - helm package ./
     - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,10 +25,13 @@ container:
 package:
   image: dtzar/helm-kubectl
   stage: build-package
+  variables:
+    HELM_REPO_URL: "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - echo "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+    - echo "$HELM_REPO_URL"
+    - helm repo index --url ${HELM_REPO_URL} .
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,7 +16,8 @@ container:
   stage: build-container
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
-    - helm chart save ./ $CHART_REGISTRY_URL
+    - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+    - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
     - helm chart push $CHART_REGISTRY_URL
   only:
     - tags
@@ -31,13 +32,10 @@ package:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - echo "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
-    - echo "++++++++++++++++++++++++++++++++"
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
-#    - helm package ./
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME
   only:
     - tags
-#    - master
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ package:
     - helm package ./
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - helm push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
+    - helm cm-push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
   only:
     - master
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -23,7 +23,7 @@ container:
     - tags
 
 package:
-  image: dtzar/helm-kubectl
+  image: dtzar/helm-kubectl:3.7.1
   stage: build-package
   variables:
     HELM_REPO_URL: "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,19 +15,16 @@ container:
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
-    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:latest
-    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:latest
+    - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+    - helm chart push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+    - helm chart save ./ $CI_REGISTRY_IMAGE:latest
+    - helm chart push $CI_REGISTRY_IMAGE:latest
   only:
     - tags
 
 package:
   image: dtzar/helm-kubectl
   stage: build-package
-  variables:
-    PACKAGE_NAME: "varnish"
-    PACKAGE_VERSION: "0.6.2"
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,9 +4,6 @@ image:
 
 variables:
   HELM_EXPERIMENTAL_OCI: 1
-  CHART_NAME: varnish-chart
-  CHART_PROGECT: tebaly/$CHART_NAME
-  CHART_REGISTRY_URL: $CI_REGISTRY/$CHART_PROGECT:$CI_COMMIT_TAG
 
 stages:
   - build-container
@@ -18,7 +15,8 @@ container:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
     - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart push $CHART_REGISTRY_URL
+    - helm chart push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+    - helm chart push $CI_REGISTRY_IMAGE:latest
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image:
-  name: alpine/helm:3.2.1
+  name: alpine/helm:3.7.1
   entrypoint: ["/bin/sh", "-c"]
 
 variables:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,10 +15,10 @@ container:
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE:latest
-    - helm chart push $CI_REGISTRY_IMAGE:latest
+    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
+    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
+    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:latest
+    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:latest
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,9 @@ package:
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME $CI_REGISTRY'
+    - echo "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
+    - echo "++++++++++++++++++++++++++++++++"
+    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
 #    - helm package ./
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,6 @@ package:
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - helm push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
   only:
-    - tags
+    - master
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ container:
     - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
     - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
     - helm chart push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
+    - helm chart save ./ $CI_REGISTRY_IMAGE:latest
     - helm chart push $CI_REGISTRY_IMAGE:latest
   only:
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,8 +34,9 @@ pages:
     - mkdir -p ./public
     - echo $HELM_REPO_URL
   script:
-    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION" --destination ./public
+    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION"
     - helm repo index ./ --url="$HELM_REPO_URL"
+    - mv "varnish-${CI_COMMIT_TAG}.tgz" ./public
     - mv index.yaml ./public
   artifacts:
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,7 @@ container:
     - tags
 
 package:
+  image: dtzar/helm-kubectl
   stage: build-package
   variables:
     PACKAGE_NAME: "varnish"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,7 +30,7 @@ package:
   before_script:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
-    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
+    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME $CI_REGISTRY'
   script:
 #    - helm package ./
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,6 +4,7 @@ image:
 
 variables:
   HELM_EXPERIMENTAL_OCI: 1
+  CHART_NAME: varnish
 
 stages:
   - build-container
@@ -14,10 +15,10 @@ container:
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - echo $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart push $CI_REGISTRY_IMAGE:$CI_COMMIT_TAG
-    - helm chart save ./ $CI_REGISTRY_IMAGE:latest
-    - helm chart push $CI_REGISTRY_IMAGE:latest
+    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
+    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:$CI_COMMIT_TAG
+    - helm chart save ./ $CI_REGISTRY_IMAGE/$CHART_NAME:latest
+    - helm chart push $CI_REGISTRY_IMAGE/$CHART_NAME:latest
   only:
     - tags
 
@@ -33,7 +34,7 @@ package:
     - echo "$CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
-    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME
+    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME/$CHART_NAME
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,7 +24,6 @@ container:
   only:
     - tags
 
-
 pages:
   image: dtzar/helm-kubectl:3.7.1
   stage: build-pages

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ image:
 variables:
   HELM_EXPERIMENTAL_OCI: 1
   CHART_NAME: varnish
+  CHART_APP_VERSION: "6.4"
 
 stages:
   - build-container
@@ -31,10 +32,11 @@ package:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - echo $HELM_REPO_URL
-    - 'helm repo index ./ --url ${HELM_REPO_URL}'
-    - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
+    - helm package . --version="$CI_COMMIT_TAG" --app-version="$CHART_APP_VERSION"
+    - helm repo index ./ --url="$HELM_REPO_URL"
+    - helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable"
   script:
-    - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME
+    - helm cm-push ./ $CI_PROJECT_NAME
   only:
     - tags
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ package:
   script:
     - echo "$CI_REGISTRY_PASSWORD" | helm registry login -u $CI_REGISTRY_USER $CI_REGISTRY --password-stdin
     - helm package ./
+    - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - helm push "${PACKAGE_NAME}-${PACKAGE_VERSION}.tgz" PACKAGE_NAME
   only:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,7 +31,7 @@ package:
     - apk add git
     - helm plugin install https://github.com/chartmuseum/helm-push.git
     - echo $HELM_REPO_URL
-    - helm repo index ./ --url $HELM_REPO_URL
+    - 'helm repo index ./ --url ${HELM_REPO_URL}'
     - 'helm repo add --username gitlab-ci-token --password $CI_JOB_TOKEN $CI_PROJECT_NAME ${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/packages/helm/stable'
   script:
     - helm cm-push ./ --version="$CI_COMMIT_TAG" $CI_PROJECT_NAME

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 image:
-  name: alpine/helm:3.7.1
+  name: alpine/helm:3.6.2
   entrypoint: ["/bin/sh", "-c"]
 
 variables:

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -3,7 +3,7 @@
   "bumpFiles": [
     {
       "filename": "Chart.yaml",
-      "updater": "standardVersionUpdaterYaml"
+      "type": "plain-text"
     }
   ]
 }

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,0 +1,9 @@
+{
+  "tagPrefix": "",
+  "bumpFiles": [
+    {
+      "filename": "Chart.yaml",
+      "updater": "standardVersionUpdaterYaml"
+    }
+  ]
+}

--- a/.versionrc.json
+++ b/.versionrc.json
@@ -1,9 +1,3 @@
 {
-  "tagPrefix": "",
-  "bumpFiles": [
-    {
-      "filename": "Chart.yaml",
-      "type": "plain-text"
-    }
-  ]
+  "tagPrefix": ""
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.13](https://github.com/tebaly/varnish-chart/compare/v0.1.12...v0.1.13) (2021-10-22)
+
+
+### Bug Fixes
+
+* networking.k8s.io/v1 ([41f0ffb](https://github.com/tebaly/varnish-chart/commit/41f0ffb9ad1a9b0f51f1b2e7d3fe053bb8a53cc5))
+
 ### [0.1.12](https://github.com/tebaly/varnish-chart/compare/v0.1.11...v0.1.12) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.9](https://github.com/tebaly/varnish-chart/compare/v0.1.8...v0.1.9) (2021-10-22)
+
+
+### Bug Fixes
+
+* api-url ([38a505b](https://github.com/tebaly/varnish-chart/commit/38a505bac20b600f29f81631320d9fc5ceb17711))
+
 ### [0.1.8](https://github.com/tebaly/varnish-chart/compare/v0.1.7...v0.1.8) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.18](https://github.com/tebaly/varnish-chart/compare/0.1.17...0.1.18) (2021-10-24)
+
 ### [0.1.17](https://github.com/tebaly/varnish-chart/compare/v0.1.16...v0.1.17) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.7](https://github.com/tebaly/varnish-chart/compare/v0.1.6...v0.1.7) (2021-10-22)
+
+
+### Bug Fixes
+
+* apk git ([b1f36f7](https://github.com/tebaly/varnish-chart/commit/b1f36f773eaf27c1291992037eb858a9f5c6dcaa))
+* apk git ([3a483ba](https://github.com/tebaly/varnish-chart/commit/3a483ba4b9f9f45e5e6690467c4194a3aba85d38))
+* ci project name ([99519c9](https://github.com/tebaly/varnish-chart/commit/99519c94e20d2b68f6dc92132458f3ec92b8b74a))
+* cm-push ([57e7331](https://github.com/tebaly/varnish-chart/commit/57e7331b4a21de812eb84a75409e2e17bed7db35))
+* could not find protocol ([22f4ae7](https://github.com/tebaly/varnish-chart/commit/22f4ae7d327b1e4222d0558bb36e16a488165b4b))
+* gitlab-ci helm ([3516232](https://github.com/tebaly/varnish-chart/commit/35162322453d44cdde8c756dce528bd649e181f1))
+* image helm-kubectl ([9688fe9](https://github.com/tebaly/varnish-chart/commit/9688fe93d5130af7be9486978e19708421397186))
+* package tag ver ([1cf9458](https://github.com/tebaly/varnish-chart/commit/1cf945875746f24727c39b8e3729250a1d27b531))
+
 ### [0.1.6](https://github.com/tebaly/varnish-chart/compare/v0.1.5...v0.1.6) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.10](https://github.com/tebaly/varnish-chart/compare/v0.1.9...v0.1.10) (2021-10-22)
+
+
+### Bug Fixes
+
+* registry image ([3c07279](https://github.com/tebaly/varnish-chart/commit/3c07279a69ca82f57894cba776ac7d4aa12d7d5a))
+
 ### [0.1.9](https://github.com/tebaly/varnish-chart/compare/v0.1.8...v0.1.9) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.15](https://github.com/tebaly/varnish-chart/compare/v0.1.14...v0.1.15) (2021-10-23)
+
+
+### Bug Fixes
+
+* package name ([8ac8506](https://github.com/tebaly/varnish-chart/commit/8ac8506745673eda37e49a6bf30072e020947916))
+
 ### [0.1.14](https://github.com/tebaly/varnish-chart/compare/v0.1.13...v0.1.14) (2021-10-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.12](https://github.com/tebaly/varnish-chart/compare/v0.1.11...v0.1.12) (2021-10-22)
+
+
+### Bug Fixes
+
+* save latest ([9c9fb67](https://github.com/tebaly/varnish-chart/commit/9c9fb67ae2d45763d4403f56779b9498a82759d4))
+
 ### [0.1.11](https://github.com/tebaly/varnish-chart/compare/v0.1.10...v0.1.11) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.16](https://github.com/tebaly/varnish-chart/compare/v0.1.15...v0.1.16) (2021-10-24)
+
+
+### Bug Fixes
+
+* oci root ([f8eccb0](https://github.com/tebaly/varnish-chart/commit/f8eccb001e879d077155f22f8066dd5639c04587))
+
 ### [0.1.15](https://github.com/tebaly/varnish-chart/compare/v0.1.14...v0.1.15) (2021-10-23)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.24](https://github.com/tebaly/varnish-chart/compare/0.1.23...0.1.24) (2021-10-24)
+
+
+### Bug Fixes
+
+* helm upd ([15f8297](https://github.com/tebaly/varnish-chart/commit/15f8297cb2198822a33b827ed86aca37d2a62d90))
+
 ### [0.1.23](https://github.com/tebaly/varnish-chart/compare/0.1.22...0.1.23) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.6](https://github.com/tebaly/varnish-chart/compare/v0.1.5...v0.1.6) (2021-10-22)
+
+
+### Bug Fixes
+
+* ci package name ([b311dfb](https://github.com/tebaly/varnish-chart/commit/b311dfb7cfc9f2b3a0c98b7d263df06d5655af6d))
+
 ### [0.1.5](https://github.com/tebaly/varnish-chart/compare/v0.1.4...v0.1.5) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.2.0](https://github.com/tebaly/varnish-chart/compare/0.1.29...0.2.0) (2021-10-25)
+
+
+### ⚠ BREAKING CHANGES
+
+* add values "image.tag"
+
+### Features
+
+* tag ver ([9fcaec2](https://github.com/tebaly/varnish-chart/commit/9fcaec23ca00f698c41e761dca2315414318ac6e))
+
 ### [0.1.29](https://github.com/tebaly/varnish-chart/compare/0.1.28...0.1.29) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.29](https://github.com/tebaly/varnish-chart/compare/0.1.28...0.1.29) (2021-10-25)
+
+
+### Features
+
+* license ([d8c55d6](https://github.com/tebaly/varnish-chart/commit/d8c55d67899c7093a956e2da016807b9e3d91c55))
+
 ### [0.1.28](https://github.com/tebaly/varnish-chart/compare/0.1.27...0.1.28) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.8](https://github.com/tebaly/varnish-chart/compare/v0.1.7...v0.1.8) (2021-10-22)
+
+
+### Bug Fixes
+
+* ci registry ([19397fe](https://github.com/tebaly/varnish-chart/commit/19397fe0eaf542152d1354204250a4765c556e67))
+
 ### [0.1.7](https://github.com/tebaly/varnish-chart/compare/v0.1.6...v0.1.7) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.19](https://github.com/tebaly/varnish-chart/compare/0.1.18...0.1.19) (2021-10-24)
+
+
+### Bug Fixes
+
+* tagPrefix version without "v" ([564984a](https://github.com/tebaly/varnish-chart/commit/564984a20b89beeb19d66a7a18cff8fc70c78222))
+
 ### [0.1.18](https://github.com/tebaly/varnish-chart/compare/0.1.17...0.1.18) (2021-10-24)
 
 ### [0.1.17](https://github.com/tebaly/varnish-chart/compare/v0.1.16...v0.1.17) (2021-10-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.4](https://github.com/tebaly/varnish-chart/compare/0.2.3...0.2.4) (2021-10-25)
+
+
+### Bug Fixes
+
+* add env.secrets values ([5a4e90c](https://github.com/tebaly/varnish-chart/commit/5a4e90c59787cbd1dfeda0978578e28a941a03be))
+
 ### [0.2.3](https://github.com/tebaly/varnish-chart/compare/0.2.2...0.2.3) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.17](https://github.com/tebaly/varnish-chart/compare/v0.1.16...v0.1.17) (2021-10-24)
+
+
+### Bug Fixes
+
+* tagPrefix ([2b31b91](https://github.com/tebaly/varnish-chart/commit/2b31b9132db0ba4f95625021fb4e13a90cdc2060))
+
 ### [0.1.16](https://github.com/tebaly/varnish-chart/compare/v0.1.15...v0.1.16) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.5](https://github.com/tebaly/varnish-chart/compare/v0.1.4...v0.1.5) (2021-10-22)
+
+
+### Bug Fixes
+
+* ci package version ([f53f381](https://github.com/tebaly/varnish-chart/commit/f53f381d4d1540eb7c457520188ad39ccc53a5e3))
+
 ### [0.1.4](https://github.com/tebaly/varnish-chart/compare/v0.1.3...v0.1.4) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.3](https://github.com/tebaly/varnish-chart/compare/0.2.2...0.2.3) (2021-10-25)
+
+
+### Bug Fixes
+
+* PodDisruptionBudget v1 ([bc2232c](https://github.com/tebaly/varnish-chart/commit/bc2232c2f5090ed5fefff2f8c41d2012f0342a48))
+
 ### [0.2.2](https://github.com/tebaly/varnish-chart/compare/0.2.1...0.2.2) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.28](https://github.com/tebaly/varnish-chart/compare/0.1.27...0.1.28) (2021-10-25)
+
+
+### Bug Fixes
+
+* build-pages ([a0a5f0b](https://github.com/tebaly/varnish-chart/commit/a0a5f0b5b2d544efc1e043224531cb9fbf9bc943))
+
 ### [0.1.27](https://github.com/tebaly/varnish-chart/compare/0.1.26...0.1.27) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.1](https://github.com/tebaly/varnish-chart/compare/0.2.0...0.2.1) (2021-10-25)
+
+
+### Bug Fixes
+
+* destination bug ([1440de3](https://github.com/tebaly/varnish-chart/commit/1440de3fbb79ba7fdeb7e4f1bba1dc9b9b500e25))
+
 ## [0.2.0](https://github.com/tebaly/varnish-chart/compare/0.1.29...0.2.0) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.2.2](https://github.com/tebaly/varnish-chart/compare/0.2.1...0.2.2) (2021-10-25)
+
+
+### Bug Fixes
+
+* ingress ([80759da](https://github.com/tebaly/varnish-chart/commit/80759dad093d6cf17e6e5bbcccbffdc844c9edbc))
+
 ### [0.2.1](https://github.com/tebaly/varnish-chart/compare/0.2.0...0.2.1) (2021-10-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.20](https://github.com/tebaly/varnish-chart/compare/0.1.19...0.1.20) (2021-10-24)
+
+
+### Bug Fixes
+
+* without bumpFiles ([cdea478](https://github.com/tebaly/varnish-chart/commit/cdea478a2782b973dc383c0ba835cbecc714be69))
+
 ### [0.1.19](https://github.com/tebaly/varnish-chart/compare/0.1.18...0.1.19) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.27](https://github.com/tebaly/varnish-chart/compare/0.1.26...0.1.27) (2021-10-25)
+
+
+### Bug Fixes
+
+* app-version ([61933ae](https://github.com/tebaly/varnish-chart/commit/61933ae8398f39606148dc8b74478f4d6309130a))
+
 ### [0.1.26](https://github.com/tebaly/varnish-chart/compare/0.1.25...0.1.26) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.22](https://github.com/tebaly/varnish-chart/compare/0.1.21...0.1.22) (2021-10-24)
+
+
+### Bug Fixes
+
+* index dir ([76de440](https://github.com/tebaly/varnish-chart/commit/76de440edebf3c756bf0af39d157d921882ef2a9))
+
 ### [0.1.21](https://github.com/tebaly/varnish-chart/compare/0.1.20...0.1.21) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.26](https://github.com/tebaly/varnish-chart/compare/0.1.25...0.1.26) (2021-10-24)
+
+
+### Bug Fixes
+
+* helm dtzar ([fe6eaba](https://github.com/tebaly/varnish-chart/commit/fe6eabaa2963d93837f2eda2cc4d71890f0c60c3))
+
 ### [0.1.25](https://github.com/tebaly/varnish-chart/compare/0.1.24...0.1.25) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.11](https://github.com/tebaly/varnish-chart/compare/v0.1.10...v0.1.11) (2021-10-22)
+
+
+### Bug Fixes
+
+* registry latest ([ac6f6c2](https://github.com/tebaly/varnish-chart/commit/ac6f6c2f4b98dc1a6748a891eceac0941e42e38a))
+
 ### [0.1.10](https://github.com/tebaly/varnish-chart/compare/v0.1.9...v0.1.10) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.23](https://github.com/tebaly/varnish-chart/compare/0.1.22...0.1.23) (2021-10-24)
+
+
+### Bug Fixes
+
+* index url ([dc40fac](https://github.com/tebaly/varnish-chart/commit/dc40facb2df8196749518ae433252d9699b54cdd))
+
 ### [0.1.22](https://github.com/tebaly/varnish-chart/compare/0.1.21...0.1.22) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.14](https://github.com/tebaly/varnish-chart/compare/v0.1.13...v0.1.14) (2021-10-23)
+
+
+### Bug Fixes
+
+* chart name ([c6d5fbb](https://github.com/tebaly/varnish-chart/commit/c6d5fbb4276dbaa89229ef712d8e449fac404da2))
+
 ### [0.1.13](https://github.com/tebaly/varnish-chart/compare/v0.1.12...v0.1.13) (2021-10-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.25](https://github.com/tebaly/varnish-chart/compare/0.1.24...0.1.25) (2021-10-24)
+
+
+### Bug Fixes
+
+* helm err ([41f8829](https://github.com/tebaly/varnish-chart/commit/41f882932647cdd4e17ddbc3ed9feba8f93ff2e9))
+
 ### [0.1.24](https://github.com/tebaly/varnish-chart/compare/0.1.23...0.1.24) (2021-10-24)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [0.1.21](https://github.com/tebaly/varnish-chart/compare/0.1.20...0.1.21) (2021-10-24)
+
+
+### Bug Fixes
+
+* index yaml ([f134242](https://github.com/tebaly/varnish-chart/commit/f1342427870fbd37136d5abbfae55944b21f48f6))
+
 ### [0.1.20](https://github.com/tebaly/varnish-chart/compare/0.1.19...0.1.20) (2021-10-24)
 
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.6.2
+version: 0.1.2
 appVersion: 6.4

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+This is free and unencumbered software released into the public domain.
+
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <https://unlicense.org>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,18 @@
 
 Helm chart for Varnish Cache
 
-## Quick Start
+## Install 
+
+### GitLab pages
 
 ```bash
-helm install --repo https://charts.softonic.io my-varnish varnish
+helm install --repo https://tebaly.gitlab.io/varnish-chart varnish varnish
+```
+
+### OCI
+```bash
+dependencies:
+  - name: varnish
+    version: "<version>"
+    repository: "oci://registry.gitlab.com/tebaly/varnish-chart"
 ```

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: varnishd
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ or .Values.image.tag .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: VARNISH_SIZE
@@ -79,7 +79,7 @@ spec:
           {{- end }}
         {{- if .Values.logging.enabled }}
         - name: varnishncsa
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - varnishncsa

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,6 +52,13 @@ spec:
           env:
             - name: VARNISH_SIZE
               value: {{ .Values.varnishSize }}
+          {{- if .Values.env.secrets }}
+          envFrom:
+            {{- range .Values.env.secrets }}
+            - secretRef:
+                name: {{ . }}
+            {{- end }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 80

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -33,9 +33,12 @@ spec:
         paths:
         {{- range .paths }}
           - path: {{ . }}
+            pathType: Prefix
             backend:
-              serviceName: {{ $fullName }}
-              servicePort: {{ $svcPort }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
         {{- end }}
   {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -2,7 +2,7 @@
 {{- $fullName := include "varnish.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
 {{- if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: extensions/v1beta1
 {{- end }}

--- a/templates/poddisruptionbudget.yaml
+++ b/templates/poddisruptionbudget.yaml
@@ -1,6 +1,6 @@
 ---
 {{- if .Values.maxUnavailable }}
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "varnish.fullname" . }}

--- a/values.yaml
+++ b/values.yaml
@@ -47,6 +47,11 @@ service:
   type: ClusterIP
   port: 80
 
+# Secret name array. Result like
+# envFrom.secretRef[0].name: secret-name
+env:
+  secrets: []
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
auto build and publish OCI + GitLab pages
  
BC: 
- image.tag values
- versioning from 0.1.0

FIX:
- add env.secrets values
- PodDisruptionBudget v1
- ingress v1
- tagPrefix version without "v"
- gitlab-ci