### PR TITLE
allow to define an image tag

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -47,7 +47,7 @@ spec:
         - name: varnishd
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: VARNISH_SIZE
@@ -79,7 +79,7 @@ spec:
           {{- end }}
         {{- if .Values.logging.enabled }}
         - name: varnishncsa
-          image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
           - varnishncsa

--- a/values.yaml
+++ b/values.yaml
@@ -9,6 +9,7 @@ maxUnavailable: 1
 image:
   repository: varnish
   pullPolicy: IfNotPresent
+  tag: ""
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This PR doesn't break BC. If the image tag is empty (""), Helm still uses `Chart.AppVersion`. Once defined (e.g. "7.0") Helm uses the tag instead of the AppVersion. This makes the chart much more flexible and it can be used even if the tag is not aligned with the AppVersion referenced in the chart.