### PR TITLE
Add support for update strategy

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,6 +11,7 @@ spec:
   selector:
     matchLabels:
       {{- include "varnish.selectorLabels" . | nindent 6 }}
+  strategy: {{- toYaml .Values.strategy | nindent 4 }}
   template:
     metadata:
       labels:

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,12 @@ autoscaling:
   maxReplicas: 10
   metrics: []
 
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxSurge: 1
+    maxUnavailable: 0
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
One might want to adjust the update strategy for bigger instances as every restart will cause a loss of cached entities.
The PR uses safe defaults, only having one unavailable Varnish instance at a time instead of the K8S default of 25%.