### PR TITLE
feat: Allow changing Varnish listening port

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.9.0
-appVersion: 6.6
+version: 0.10.0
+appVersion: 7.2.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -52,7 +52,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: VARNISH_SIZE
-              value: {{ .Values.varnishSize }}
+              value: "{{ .Values.varnishSize }}"
+            - name: VARNISH_HTTP_PORT
+              value: "{{ .Values.varnishListeningPort }}"
           {{- if .Values.arguments }}
           args:
             {{  range .Values.arguments }}
@@ -61,7 +63,7 @@ spec:
           {{- end }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.varnishListeningPort }}
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,8 @@ replicaCount: 1
 
 maxUnavailable: 1
 
+varnishListeningPort: 80
+
 image:
   repository: varnish
   pullPolicy: IfNotPresent
@@ -120,7 +122,7 @@ prometheus:
   enabled: false
   image:
     repository: softonic/varnish
-    tag: 6.4
+    tag: 7.2.1
     pullPolicy: IfNotPresent
   path: "/metrics"
   port: "9131"


### PR DESCRIPTION
Varnish 7.2.1 is setting the user `varnish` instead of root, what produces an error when starting. Check this [issue](https://github.com/varnish/docker-varnish/issues/42).

This PR is to add an option to configure varnish listening port.