### PR TITLE
Allow use of nodePort in Varnish service

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.10.0
+version: 0.11.0
 appVersion: 7.2.1

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -12,6 +12,9 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      {{- with .Values.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
       targetPort: http
       protocol: TCP
       name: http

--- a/values.yaml
+++ b/values.yaml
@@ -55,6 +55,7 @@ service:
   type: ClusterIP
   port: 80
   annotations: {}
+  nodePort: null
 
 ingress:
   enabled: false


### PR DESCRIPTION
With this change we can start varnish in nodePort so in devel environment we can bind to it 