### PR TITLE
Allow to define extra volumes for deployment

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.12.0
+version: 0.13.0
 appVersion: 7.2.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if or .Values.logging.enabled (or .Values.vcl .Values.vclConfigmap) }}
+          {{- if or .Values.logging.enabled .Values.vcl .Values.vclConfigmap .Values.extraVolumeMounts }}
           volumeMounts:
           {{- end }}
           {{- if .Values.logging.enabled }}
@@ -77,6 +77,9 @@ spec:
           {{- if or .Values.vcl .Values.vclConfigmap }}
           - name: vcl-configmap
             mountPath: /etc/varnish
+          {{- end }}
+          {{- if .Values.extraVolumeMounts }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
@@ -134,16 +137,17 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- if or .Values.logging.enabled (or .Values.vcl .Values.vclConfigmap)}}
+    {{- if or .Values.logging.enabled .Values.vcl .Values.vclConfigmap .Values.extraVolumes }}
       volumes:
+      {{- if .Values.logging.enabled }}
       - name: vsm
         emptyDir:
           medium: Memory
           {{- if .Values.vsmMemorySizeLimit }}
           sizeLimit: {{ .Values.vsmMemorySizeLimit }}
           {{- end }}
-    {{- end }}
-    {{- if or .Values.vcl .Values.vclConfigmap }}
+      {{- end }}
+      {{- if or .Values.vcl .Values.vclConfigmap }}
       - name: vcl-configmap
         configMap:
       {{- if .Values.vclConfigmap }}
@@ -151,4 +155,9 @@ spec:
       {{ else if .Values.vcl }}
           name: {{ include "varnish.fullname" . }}
       {{- end }}
+      {{- end }}
+      {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+      {{- end }}
     {{- end }}
+

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,16 @@ strategy:
     maxSurge: 1
     maxUnavailable: 0
 
+extraVolumes:
+  []
+  # - name: disk-cache
+  #   emptyDir: {}
+
+extraVolumeMounts:
+  []
+  # - name: disk-cache
+  #   mountPath: /mnt/disk-cache
+
 service:
   type: ClusterIP
   port: 80
@@ -75,6 +85,8 @@ ingress:
 vsmMemorySizeLimit: null
 
 arguments: {}
+#  - -s
+#  - diskcache=file,/mnt/disk-cache,10g
 #  - -p
 #  - http_resp_hdr_len=20480
 


### PR DESCRIPTION
Implements #29.

Discussion: On restarts a deployment gets a fresh PV, so only ephemeral volumes like _emptyDir_ are actually used. Only StatefulSets can benefit from _volumeClaimTemplates_. Therefore a lightweight approach has been chosen to define extra volumes for varnish deployments.