### PR TITLE
Fix indent for extra volumes

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: varnish
 description: A Varnish Cache Helm chart for Kubernetes
 type: application
-version: 0.13.0
+version: 0.13.1
 appVersion: 7.2.1

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             mountPath: /etc/varnish
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
-          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
@@ -157,7 +157,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
     {{- end }}
 


### PR DESCRIPTION
The changes introduced in #30 had a bug in the indent which caused a Helm error.

Steps to reproduce:
1. Add this for values.yaml
```
extraVolumes:
  - name: disk-cache
    emptyDir: {}

extraVolumeMounts:
  - name: disk-cache
    mountPath: /mnt
```

2. Run `helm template . `. The following error will occur:
```
Error: YAML parse error on varnish/templates/deployment.yaml: error converting YAML to JSON: yaml: line 57: did not find expected key
```
3. Decrease the nindent in `templates/deployment.yaml`:
```
diff --git a/templates/deployment.yaml b/templates/deployment.yaml
index 9d173d9..53144e4 100644
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             mountPath: /etc/varnish
           {{- end }}
           {{- if .Values.extraVolumeMounts }}
-          {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+          {{- toYaml .Values.extraVolumeMounts | nindent 10 }}
           {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe:
@@ -157,7 +157,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Values.extraVolumes }}
-        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- toYaml .Values.extraVolumes | nindent 6 }}
       {{- end }}
     {{- end }}
```
4. Run `helm template .` again, which should succeed.