### PR TITLE
Fix erroneous line feed in varnish.image.

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -77,9 +77,9 @@ Return supported apiVersion for poddisruptionbudget
 Create the name of the image to use
 */}}
 {{- define "varnish.image" -}}
-{{- if .Values.imageFullnameOverride }}
+{{- if .Values.imageFullnameOverride -}}
 {{- .Values.imageFullnameOverride -}}
-{{- else }}
+{{- else -}}
 {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-{{- end }}
-{{- end }}
+{{- end -}}
+{{- end -}}


### PR DESCRIPTION
This removes an unwanted line feed that appears when `imageFullnameOverride` is _not_ provided. The extra line feed causes the problem:
```
[ERROR] templates/deployment.yaml: unable to parse YAML: error converting YAML to JSON: yaml: line 41: could not find expected ':'
```

**Before**
```
% helm template . --debug 2>&1 | grep -A2 image:
          image:
varnish:7.2.1
          imagePullPolicy: IfNotPresent
--
          image:
varnish:7.2.1
          imagePullPolicy: IfNotPresent
```

**After**
```
% helm template . --debug 2>&1 | grep -A2 image:
          image: varnish:7.2.1
          imagePullPolicy: IfNotPresent
          env:
--
          image: varnish:7.2.1
          imagePullPolicy: IfNotPresent
          command:
```